### PR TITLE
CORE-1328 Switch to modern service definition

### DIFF
--- a/monk.rb
+++ b/monk.rb
@@ -21,33 +21,10 @@ class Monk < Formula
     bin.install "monkd" => "monkd"
   end
 
-  plist_options manual: "monkd"
-
-  def plist
-    <<~EOS
-      <?xml version="1.0" encoding="UTF-8"?>
-      <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-      <plist version="1.0">
-        <dict>
-          <key>Label</key>
-          <string>#{plist_name}</string>
-          <key>RunAtLoad</key>
-          <true/>
-          <key>EnableGlobbing</key>
-          <true/>
-          <key>ProgramArguments</key>
-          <array>
-            <string>/usr/local/bin/monkd</string>
-          </array>
-          <key>StandardErrorPath</key>
-          <string>/tmp/com.monkd.daemon.plist.error.log</string>
-          <key>StandardOutPath</key>
-          <string>/tmp/com.monkd.daemon.plist.log</string>
-          <key>UserName</key>
-          <string>{{USERNAME}}</string>
-        </dict>
-      </plist>
-    EOS
+  service do
+    run [opt_bin/"monkd"]
+    working_dir HOMEBREW_PREFIX
+    log_path var/"log/monkd/output.log"
+    error_log_path var/"log/monkd/error.log"
   end
-
 end

--- a/monk.rb
+++ b/monk.rb
@@ -16,15 +16,30 @@ class Monk < Formula
     url url_arm64
   end
 
+#  depends_on "podman" => :recommended
+
   def install
     bin.install "monk" => "monk"
     bin.install "monkd" => "monkd"
   end
 
-  service do
-    run [opt_bin/"monkd"]
-    working_dir HOMEBREW_PREFIX
-    log_path var/"log/monkd/output.log"
-    error_log_path var/"log/monkd/error.log"
+  def post_install
+    (var/"log/monk").mkpath
   end
+
+  def caveats; <<~EOS
+    Initialize the monk machine with monk daemon inside
+      monk machine init
+
+    Upgrade monk daemon inside the machine machine to the latest version
+      monk machine upgrade
+    EOS
+  end
+
+#  service do
+#    run ["#{bin}/monkd"]
+#    working_dir HOMEBREW_PREFIX
+#    log_path var/"log/monk/output.log"
+#    error_log_path var/"log/monk/error.log"
+#  end
 end

--- a/monk.rb
+++ b/monk.rb
@@ -16,15 +16,11 @@ class Monk < Formula
     url url_arm64
   end
 
-#  depends_on "podman" => :recommended
+  depends_on "podman" => :recommended
 
   def install
     bin.install "monk" => "monk"
     bin.install "monkd" => "monkd"
-  end
-
-  def post_install
-    (var/"log/monk").mkpath
   end
 
   def caveats; <<~EOS
@@ -35,11 +31,4 @@ class Monk < Formula
       monk machine upgrade
     EOS
   end
-
-#  service do
-#    run ["#{bin}/monkd"]
-#    working_dir HOMEBREW_PREFIX
-#    log_path var/"log/monk/output.log"
-#    error_log_path var/"log/monk/error.log"
-#  end
 end

--- a/monk.rb.template
+++ b/monk.rb.template
@@ -21,33 +21,10 @@ class Monk < Formula
     bin.install "monkd" => "monkd"
   end
 
-  plist_options manual: "monkd"
-
-  def plist
-    <<~EOS
-      <?xml version="1.0" encoding="UTF-8"?>
-      <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-      <plist version="1.0">
-        <dict>
-          <key>Label</key>
-          <string>#{plist_name}</string>
-          <key>RunAtLoad</key>
-          <true/>
-          <key>EnableGlobbing</key>
-          <true/>
-          <key>ProgramArguments</key>
-          <array>
-            <string>/usr/local/bin/monkd</string>
-          </array>
-          <key>StandardErrorPath</key>
-          <string>/tmp/com.monkd.daemon.plist.error.log</string>
-          <key>StandardOutPath</key>
-          <string>/tmp/com.monkd.daemon.plist.log</string>
-          <key>UserName</key>
-          <string>{{USERNAME}}</string>
-        </dict>
-      </plist>
-    EOS
+  service do
+    run [opt_bin/"monkd"]
+    working_dir HOMEBREW_PREFIX
+    log_path var/"log/monkd/output.log"
+    error_log_path var/"log/monkd/error.log"
   end
-
 end

--- a/monk.rb.template
+++ b/monk.rb.template
@@ -16,15 +16,30 @@ class Monk < Formula
     url url_arm64
   end
 
+#  depends_on "podman" => :recommended
+
   def install
     bin.install "monk" => "monk"
     bin.install "monkd" => "monkd"
   end
 
-  service do
-    run [opt_bin/"monkd"]
-    working_dir HOMEBREW_PREFIX
-    log_path var/"log/monkd/output.log"
-    error_log_path var/"log/monkd/error.log"
+  def post_install
+    (var/"log/monk").mkpath
   end
+
+  def caveats; <<~EOS
+    Initialize the monk machine with monk daemon inside
+      monk machine init
+
+    Upgrade monk daemon inside the machine machine to the latest version
+      monk machine upgrade
+    EOS
+  end
+
+#  service do
+#    run ["#{bin}/monkd"]
+#    working_dir HOMEBREW_PREFIX
+#    log_path var/"log/monk/output.log"
+#    error_log_path var/"log/monk/error.log"
+#  end
 end

--- a/monk.rb.template
+++ b/monk.rb.template
@@ -16,15 +16,11 @@ class Monk < Formula
     url url_arm64
   end
 
-#  depends_on "podman" => :recommended
+  depends_on "podman" => :recommended
 
   def install
     bin.install "monk" => "monk"
     bin.install "monkd" => "monkd"
-  end
-
-  def post_install
-    (var/"log/monk").mkpath
   end
 
   def caveats; <<~EOS
@@ -35,11 +31,4 @@ class Monk < Formula
       monk machine upgrade
     EOS
   end
-
-#  service do
-#    run ["#{bin}/monkd"]
-#    working_dir HOMEBREW_PREFIX
-#    log_path var/"log/monk/output.log"
-#    error_log_path var/"log/monk/error.log"
-#  end
 end


### PR DESCRIPTION
Homebrew script does not create brew service for monkd anymore, just show information how to use monk machine

Homebrew has officially deprecated the plist_options command, causing various invocations of brew
```
➜  ~ brew install monk-io/monk/monk
Warning: Calling plist_options is deprecated! Use service.require_root instead.
Please report this issue to the monk-io/monk tap (not Homebrew/brew or Homebrew/homebrew-core), or even better, submit a PR to fix it:
  /usr/local/Homebrew/Library/Taps/monk-io/homebrew-monk/monk.rb:24

==> Fetching monk-io/monk/monk
==> Downloading https://get.monk.io/stable/macos/monk-darwin-v3.9.0.tar.gz
Already downloaded: /Users/artem/Library/Caches/Homebrew/downloads/25bf8c4dee2c0a87d7f885df0e807fe9a50746baa8cb80cda834e0f0b79e6dea--monk-darwin-v3.9.0.tar.gz
==> Installing monk from monk-io/monk
Warning: Calling plist_options is deprecated! Use service.require_root instead.
Please report this issue to the monk-io/monk tap (not Homebrew/brew or Homebrew/homebrew-core), or even better, submit a PR to fix it:
  /usr/local/Homebrew/Library/Taps/monk-io/homebrew-monk/monk.rb:24
```
