### PR TITLE
fix: typo

### DIFF
--- a/monk.rb
+++ b/monk.rb
@@ -27,7 +27,7 @@ class Monk < Formula
     Initialize the monk machine with monk daemon inside
       monk machine init
 
-    Upgrade monk daemon inside the machine machine to the latest version
+    Upgrade monk daemon inside the monk machine to the latest version
       monk machine upgrade
     EOS
   end

--- a/monk.rb.template
+++ b/monk.rb.template
@@ -27,7 +27,7 @@ class Monk < Formula
     Initialize the monk machine with monk daemon inside
       monk machine init
 
-    Upgrade monk daemon inside the machine machine to the latest version
+    Upgrade monk daemon inside the monk machine to the latest version
       monk machine upgrade
     EOS
   end


### PR DESCRIPTION
`machine machine` -> `monk machine`